### PR TITLE
Fix chat E2E test for duplicate textarea strict mode violation

### DIFF
--- a/components/chat-interface-optimized.tsx
+++ b/components/chat-interface-optimized.tsx
@@ -521,6 +521,7 @@ export default function ChatInterface() {
               <div className="rounded-2xl border border-border bg-background shadow-md flex flex-col">
                 <Textarea
                   ref={inputRef}
+                  data-testid="chat-input"
                   value={input}
                   onChange={handleInputChange}
                   placeholder={t("Type your legal question...")}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -21,9 +21,13 @@ test.describe("PocketLawyer smoke", () => {
 
   test("chat page loads for guests", async ({ page }) => {
     await page.goto("/chat");
-    await expect(
-      page.getByPlaceholder(/Type your legal question|Posez votre question/i)
-    ).toBeVisible({ timeout: 15_000 });
+    await page.waitForLoadState("domcontentloaded");
+
+    const chatInput = page.getByTestId("chat-input");
+    await expect(chatInput.first()).toBeVisible({ timeout: 15_000 });
+
+    // Guard against duplicate ChatInterface mounts (e.g. during hydration)
+    await expect(chatInput).toHaveCount(1, { timeout: 5_000 });
   });
 
   test("removed duplicate routes return 404", async ({ request }) => {


### PR DESCRIPTION
Add data-testid on chat input and target it in Playwright instead of placeholder regex, which matched two elements during hydration.