### PR TITLE
Fix chat history 401 for guests and improve authenticated API auth

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -52,7 +52,9 @@ export function AppSidebar() {
   const { user, signOut, getTrialConversationsRemaining } = useAuth()
   const { t } = useLanguage()
   const router = useRouter()
-  const { chatHistory, loading, deleteChat, renameChat } = useChatHistory(user?.id)
+  const { chatHistory, loading, deleteChat, renameChat } = useChatHistory(
+    user && !user.isAnonymous ? user.id : undefined
+  )
   const { isAdmin, isApprovedLawyer } = useRoleCheck()
   const [currentChatId, setCurrentChatId] = useState<string | null>(null)
   const isMobile = useIsMobile()

--- a/components/chat-interface-optimized.tsx
+++ b/components/chat-interface-optimized.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/contexts/auth-context"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useLanguage } from "@/contexts/language-context"
 import { useChatHistory } from "@/hooks/use-chat-history"
+import { chatManageFetch } from "@/lib/chat-api-client"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useSearchParams, useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -79,7 +80,9 @@ export default function ChatInterface() {
     navigateSearchResults,
   } = useMessageSearch(messages)
 
-  const { saveChat, updateChat } = useChatHistory(user?.id)
+  const { saveChat, updateChat } = useChatHistory(
+    user && !user.isAnonymous ? user.id : undefined
+  )
 
   // Ref to track the chatId of the conversation currently being edited, which may
   // differ from the URL param before the first save creates a Firestore document.
@@ -228,9 +231,7 @@ export default function ChatInterface() {
       if (!chatId || !user?.id || initialLoadComplete) return
 
       try {
-        const response = await fetch(`/api/chat/manage?chatId=${chatId}`, {
-          credentials: 'include',
-        })
+        const response = await chatManageFetch(`/api/chat/manage?chatId=${chatId}`)
         if (response.status === 404) {
           toast.error("Chat not found")
           router.push("/")

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -379,6 +379,7 @@ function AuthProviderContent({ children }: { children: ReactNode }) {
           // Create a session cookie
           const response = await fetch('/api/auth/session', {
             method: 'POST',
+            credentials: 'include',
             headers: {
               'Content-Type': 'application/json',
             },
@@ -410,7 +411,7 @@ function AuthProviderContent({ children }: { children: ReactNode }) {
         setUser(anonymousUser);
         
         // Clear the session cookie without waiting
-        fetch('/api/auth/session', { method: 'DELETE' }).catch(console.error);
+        fetch('/api/auth/session', { method: 'DELETE', credentials: 'include' }).catch(console.error);
       }
       setLoading(false);
     });
@@ -464,6 +465,7 @@ function AuthProviderContent({ children }: { children: ReactNode }) {
       // Set the session cookie
       await fetch('/api/auth/session', {
         method: 'POST',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/hooks/use-chat-history.ts
+++ b/hooks/use-chat-history.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Message } from 'ai';
+import { chatManageFetch } from '@/lib/chat-api-client';
 
 export interface ChatSession {
   id: string;
@@ -12,6 +13,10 @@ export interface ChatHistory {
   [date: string]: ChatSession[];
 }
 
+/**
+ * Load and sync chat history for signed-in users only.
+ * Pass `undefined` for userId when the user is anonymous or not authenticated.
+ */
 export function useChatHistory(userId: string | undefined) {
   const [chatHistory, setChatHistory] = useState<ChatHistory>({});
   const [loading, setLoading] = useState(false);
@@ -25,19 +30,22 @@ export function useChatHistory(userId: string | undefined) {
     const loadChatHistory = async () => {
       setLoading(true);
       try {
-        console.log(`Fetching chat history for userId: ${userId}`);
-        const response = await fetch(`/api/chat/manage?userId=${encodeURIComponent(userId)}`, {
-          credentials: 'include',
-        });
-        
+        const response = await chatManageFetch(
+          `/api/chat/manage?userId=${encodeURIComponent(userId)}`
+        );
+
+        if (response.status === 401) {
+          setChatHistory({});
+          return;
+        }
+
         if (!response.ok) {
           const errorText = await response.text().catch(() => 'No error details available');
           console.error(`Chat history fetch failed: ${response.status} ${response.statusText}`, errorText);
           throw new Error(`Failed to fetch chat history: ${response.status} ${response.statusText}`);
         }
-        
+
         const chats = await response.json();
-        console.log(`Successfully fetched ${chats.length} chats`);
         const history: ChatHistory = {};
 
         chats.forEach((chat: ChatSession & { userId: string }) => {
@@ -67,7 +75,6 @@ export function useChatHistory(userId: string | undefined) {
 
   const saveChat = async (messages: Message[]) => {
     if (!userId || messages.length === 0) {
-      console.warn("Cannot save chat: missing userId or no messages");
       return null;
     }
 
@@ -80,40 +87,34 @@ export function useChatHistory(userId: string | undefined) {
         timestamp: Date.now(),
       };
 
-      console.log("Attempting to save chat:", { userId, messageCount: messages.length });
-      const response = await fetch('/api/chat/manage', {
+      const response = await chatManageFetch('/api/chat/manage', {
         method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(chatData),
       });
 
       const data = await response.json();
-      
+
       if (!response.ok) {
         console.error(`Failed to save chat: ${response.status}`, data);
         throw new Error(`Failed to save chat: ${data.error || response.statusText}`);
       }
-      
-      console.log(`Chat saved successfully with ID: ${data.id}`);
-      
-      // Update local state with the new chat
+
       const date = new Date().toISOString().split('T')[0];
       const updatedHistory = { ...chatHistory };
-      
+
       if (!updatedHistory[date]) {
         updatedHistory[date] = [];
       }
-      
+
       updatedHistory[date].unshift({
         id: data.id,
         title,
         messages,
         timestamp: Date.now(),
       });
-      
+
       setChatHistory(updatedHistory);
-      
+
       return data.id;
     } catch (error) {
       console.error('Error saving chat:', error);
@@ -126,11 +127,9 @@ export function useChatHistory(userId: string | undefined) {
 
     try {
       const title = messages[0].content.slice(0, 30) + (messages[0].content.length > 30 ? '...' : '');
-      
-      const response = await fetch('/api/chat/manage', {
+
+      const response = await chatManageFetch('/api/chat/manage', {
         method: 'PUT',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           chatId,
           messages,
@@ -141,10 +140,9 @@ export function useChatHistory(userId: string | undefined) {
 
       if (!response.ok) throw new Error('Failed to update chat');
 
-      // Update local state
       const date = new Date().toISOString().split('T')[0];
       const updatedHistory = { ...chatHistory };
-      
+
       Object.keys(updatedHistory).forEach((oldDate) => {
         updatedHistory[oldDate] = updatedHistory[oldDate].filter((chat) => chat.id !== chatId);
         if (updatedHistory[oldDate].length === 0) {
@@ -174,7 +172,6 @@ export function useChatHistory(userId: string | undefined) {
 
     const originalTitle = chatHistory[Object.keys(chatHistory).find(date => chatHistory[date].some(chat => chat.id === chatId)) || '']?.find(chat => chat.id === chatId)?.title;
 
-    // Optimistic UI update
     const updatedHistory = { ...chatHistory };
     let updated = false;
     Object.keys(updatedHistory).forEach((date) => {
@@ -189,19 +186,14 @@ export function useChatHistory(userId: string | undefined) {
     }
 
     try {
-      const response = await fetch('/api/chat/manage', {
+      const response = await chatManageFetch('/api/chat/manage', {
         method: 'PUT',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ chatId, title: newTitle.trim() }),
       });
 
       if (!response.ok) throw new Error('Failed to rename chat');
-      // No need to update state again if successful
-
     } catch (error) {
       console.error('Error renaming chat:', error);
-      // Revert optimistic update on error
       if (updated && originalTitle) {
         const revertedHistory = { ...chatHistory };
          Object.keys(revertedHistory).forEach((date) => {
@@ -212,8 +204,6 @@ export function useChatHistory(userId: string | undefined) {
         });
         setChatHistory(revertedHistory);
       }
-      // Optionally show an error toast
-      // toast.error("Failed to rename chat"); 
     }
   };
 
@@ -221,16 +211,13 @@ export function useChatHistory(userId: string | undefined) {
     if (!userId) return;
 
     try {
-      const response = await fetch('/api/chat/manage', {
+      const response = await chatManageFetch('/api/chat/manage', {
         method: 'DELETE',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ chatId }),
       });
 
       if (!response.ok) throw new Error('Failed to delete chat');
-      
-      // Update local state
+
       const newHistory = { ...chatHistory };
       Object.keys(newHistory).forEach((date) => {
         newHistory[date] = newHistory[date].filter((chat) => chat.id !== chatId);
@@ -250,6 +237,6 @@ export function useChatHistory(userId: string | undefined) {
     saveChat,
     updateChat,
     deleteChat,
-    renameChat, // Export renameChat
+    renameChat,
   };
 }

--- a/lib/chat-api-client.ts
+++ b/lib/chat-api-client.ts
@@ -1,0 +1,31 @@
+import { auth } from "@/lib/firebase";
+
+/**
+ * Fetch wrapper for /api/chat/manage — sends session cookie and Firebase ID token.
+ */
+export async function chatManageFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  const headers = new Headers(init?.headers);
+
+  if (init?.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const firebaseUser = auth.currentUser;
+  if (firebaseUser && !firebaseUser.isAnonymous) {
+    try {
+      const token = await firebaseUser.getIdToken();
+      headers.set("Authorization", `Bearer ${token}`);
+    } catch {
+      // Cookie-only auth may still work
+    }
+  }
+
+  return fetch(input, {
+    ...init,
+    credentials: "include",
+    headers,
+  });
+}


### PR DESCRIPTION
- Skip chat history sync for anonymous users (no session cookie)
- Add chatManageFetch with Bearer token + credentials for manage API
- Handle 401 silently when history is unavailable
- Include credentials on Firebase session cookie requests