### PR TITLE
Fix tsc failing on stale .next route types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build:next": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .next",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,12 +31,12 @@
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    "**/*.tsx"
   ],
   "exclude": [
     "node_modules",
+    ".next",
+    "e2e",
     "**/*.test.ts",
     "**/*.test.tsx"
   ]


### PR DESCRIPTION
Remove generated .next/types from tsconfig include so deleted routes (sign-in-new, sign-up-new) in an old cache no longer break tsc. Add typecheck and clean scripts.